### PR TITLE
[UPD] set type module to use import

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,6 @@
 <body>
     
 
-    <script src="app.js"></script>
+    <script src="app.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
Lorsque tu veux utiliser une librairy js qui utilise `import` dans son code source, il est preferable d'ajouter le type, pour que le navigateur puissent le prendre en charge.